### PR TITLE
Mirror of Nike-Inc riposte#93

### DIFF
--- a/riposte-core/src/main/java/com/nike/riposte/server/channelpipeline/HttpChannelInitializer.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/channelpipeline/HttpChannelInitializer.java
@@ -561,7 +561,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
         p.addLast(
             CHANNEL_PIPELINE_FINALIZER_HANDLER_NAME,
             new ChannelPipelineFinalizerHandler(
-                exceptionHandlingHandler, responseSender, metricsListener, workerChannelIdleTimeoutMillis
+                exceptionHandlingHandler, responseSender, metricsListener, accessLogger, workerChannelIdleTimeoutMillis
             )
         );
 

--- a/riposte-core/src/test/groovy/com/nike/riposte/server/handler/AccessLogEndHandlerSpec.groovy
+++ b/riposte-core/src/test/groovy/com/nike/riposte/server/handler/AccessLogEndHandlerSpec.groovy
@@ -47,7 +47,7 @@ class AccessLogEndHandlerSpec extends Specification {
       logger.clearAll()
 
       HttpProcessingState state = Mock(HttpProcessingState)
-      state.getRequestStartTime() >> Instant.EPOCH
+      state.calculateTotalRequestTimeMillis() >> 42
       state.getResponseInfo() >> Mock(ResponseInfo)
       ChannelAttributes.getHttpProcessingStateForChannel(_) >> state
       ChannelHandlerContext mockContext = Mock(ChannelHandlerContext)
@@ -72,6 +72,8 @@ class AccessLogEndHandlerSpec extends Specification {
         def (ChannelHandlerContext mockContext, HttpProcessingState state) = mockContext()
         ChannelFuture channelFutureMock = Mock(ChannelFuture)
         RequestInfo requestInfoMock = Mock(RequestInfo)
+        Long expectedElapsedTimeMillis = state.calculateTotalRequestTimeMillis()
+        assert expectedElapsedTimeMillis != null
         state.getResponseWriterFinalChunkChannelFuture() >> channelFutureMock
         state.isResponseSent() >> true
         state.getRequestInfo() >> requestInfoMock
@@ -89,7 +91,7 @@ class AccessLogEndHandlerSpec extends Specification {
         HttpResponse actualResponseObjectMock = state.getActualResponseObject()
         ResponseInfo responseInfoMock = state.getResponseInfo()
         boolean accessLoggerCalled = false
-        accessLogger.log(_ as RequestInfo, actualResponseObjectMock, responseInfoMock, _ as Long) >> {
+        accessLogger.log(_ as RequestInfo, actualResponseObjectMock, responseInfoMock, expectedElapsedTimeMillis) >> {
           accessLoggerCalled = true
           return null
         }
@@ -105,7 +107,7 @@ class AccessLogEndHandlerSpec extends Specification {
 
   protected List mockContext() {
     HttpProcessingState state = Mock(HttpProcessingState)
-    state.getRequestStartTime() >> Instant.EPOCH
+    state.calculateTotalRequestTimeMillis() >> 42
     state.getResponseInfo() >> Mock(ResponseInfo)
     state.getActualResponseObject() >> Mock(HttpResponse)
     ChannelAttributes.getHttpProcessingStateForChannel(_) >> state

--- a/riposte-core/src/test/groovy/com/nike/riposte/server/handler/AccessLogStartHandlerSpec.groovy
+++ b/riposte-core/src/test/groovy/com/nike/riposte/server/handler/AccessLogStartHandlerSpec.groovy
@@ -6,9 +6,11 @@ import com.nike.riposte.server.http.HttpProcessingState
 import io.netty.channel.Channel
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.HttpRequest
+import io.netty.handler.codec.http.LastHttpContent
 import io.netty.util.Attribute
 import io.netty.util.AttributeKey
 import spock.lang.Specification
+import spock.lang.Unroll
 import uk.org.lidalia.slf4jext.Level
 import uk.org.lidalia.slf4jtest.TestLogger
 import uk.org.lidalia.slf4jtest.TestLoggerFactory
@@ -32,14 +34,30 @@ class AccessLogStartHandlerSpec extends Specification {
     given: "an AccessLogStartHandler"
       AccessLogStartHandler handler = new AccessLogStartHandler()
       def (ChannelHandlerContext mockContext, HttpProcessingState state) = mockContext()
+      assert state.getRequestStartTime() == null
+      assert state.getRequestStartTimeNanos() == null
     when: "we call doChannelRead()"
       PipelineContinuationBehavior response = handler.doChannelRead(mockContext, Mock(HttpRequest))
     then:
       response == PipelineContinuationBehavior.CONTINUE
-      state.getRequestStartTime().class == Instant
+      state.getRequestStartTime() != null
+      state.getRequestStartTimeNanos() != null
   }
 
-  def "doChannelRead() - null HttpProcessingState"() {
+  def "doChannelRead() - message is LastHttpContent"() {
+    given: "an AccessLogStartHandler"
+      AccessLogStartHandler handler = new AccessLogStartHandler()
+      def (ChannelHandlerContext mockContext, HttpProcessingState state) = mockContext()
+      assert state.getRequestLastChunkArrivedTimeNanos() == null
+    when: "we call doChannelRead()"
+      PipelineContinuationBehavior response = handler.doChannelRead(mockContext, Mock(LastHttpContent))
+    then:
+      response == PipelineContinuationBehavior.CONTINUE
+      state.getRequestLastChunkArrivedTimeNanos() != null
+  }
+
+  @Unroll
+  def "doChannelRead() - null HttpProcessingState - message type: #message"(Object message) {
     given: "an AccessLogStartHandler"
       AccessLogStartHandler handler = new AccessLogStartHandler()
       HttpProcessingState state = new HttpProcessingState()
@@ -55,12 +73,15 @@ class AccessLogStartHandlerSpec extends Specification {
       mockContext.channel() >> mockChannel
 
     when: "we call doChannelRead()"
-      PipelineContinuationBehavior response = handler.doChannelRead(mockContext, Mock(HttpRequest))
+      PipelineContinuationBehavior response = handler.doChannelRead(mockContext, message)
     then:
       response == PipelineContinuationBehavior.CONTINUE
       logger.getAllLoggingEvents().size() == 1
       logger.getAllLoggingEvents().get(0).level == Level.WARN
       logger.getAllLoggingEvents().get(0).message.contains("HttpProcessingState is null")
+
+    where:
+      message << [Mock(HttpRequest), Mock(LastHttpContent)]
   }
 
   protected List mockContext() {

--- a/riposte-core/src/test/java/com/nike/riposte/server/channelpipeline/HttpChannelInitializerTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/channelpipeline/HttpChannelInitializerTest.java
@@ -1104,11 +1104,13 @@ public class HttpChannelInitializerTest {
     }
 
     @Test
-    public void initChannel_adds_ChannelPipelineFinalizerHandler_as_the_last_handler_and_uses_the_ExceptionHandlingHandler_handler_and_responseSender_and_metricsListener() {
+    public void initChannel_adds_ChannelPipelineFinalizerHandler_as_the_last_handler_and_passes_the_expected_args() {
         // given
         HttpChannelInitializer hci = basicHttpChannelInitializerNoUtilityHandlers();
         MetricsListener expectedMetricsListener = mock(MetricsListener.class);
+        AccessLogger expectedAccessLogger = mock(AccessLogger.class);
         Whitebox.setInternalState(hci, "metricsListener", expectedMetricsListener);
+        Whitebox.setInternalState(hci, "accessLogger", expectedAccessLogger);
         ResponseSender expectedResponseSender = extractField(hci, "responseSender");
 
         // when
@@ -1131,10 +1133,12 @@ public class HttpChannelInitializerTest {
         ExceptionHandlingHandler actualExceptionHandlingHandler = (ExceptionHandlingHandler) Whitebox.getInternalState(channelPipelineFinalizerHandler.getRight(), "exceptionHandlingHandler");
         ResponseSender actualResponseSender = (ResponseSender) Whitebox.getInternalState(channelPipelineFinalizerHandler.getRight(), "responseSender");
         MetricsListener actualMetricsListener = (MetricsListener) Whitebox.getInternalState(channelPipelineFinalizerHandler.getRight(), "metricsListener");
+        AccessLogger actualAccessLogger = (AccessLogger) Whitebox.getInternalState(channelPipelineFinalizerHandler.getRight(), "accessLogger");
 
         assertThat(actualExceptionHandlingHandler, is(expectedExceptionHandlingHandlerPair.getRight()));
         assertThat(actualResponseSender, is(expectedResponseSender));
         assertThat(actualMetricsListener, is(expectedMetricsListener));
+        Assertions.assertThat(actualAccessLogger).isSameAs(expectedAccessLogger);
     }
 
     @Test

--- a/riposte-spi/src/main/java/com/nike/riposte/server/logging/AccessLogger.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/logging/AccessLogger.java
@@ -424,7 +424,7 @@ public class AccessLogger {
             Pair.of("raw_content_length-Req", String.valueOf(request.getRawContentLengthInBytes())),
             Pair.of("raw_content_length-Res", uncompressedRawContentLength),
             Pair.of("final_content_length-Res", finalContentLength),
-            Pair.of("elapsed_time_millis", String.valueOf(elapsedTimeMillis))
+            Pair.of("elapsed_time_millis", (elapsedTimeMillis == null) ? null : elapsedTimeMillis.toString())
         ));
 
         List<Pair<String, String>> customApplicationLogMessageExtras =

--- a/riposte-spi/src/main/java/com/nike/riposte/server/logging/AccessLogger.java
+++ b/riposte-spi/src/main/java/com/nike/riposte/server/logging/AccessLogger.java
@@ -419,7 +419,6 @@ public class AccessLogger {
             Pair.of("error_uid-Res", errorUid),
             Pair.of(TRACE_ENABLED + "-Req", request.getHeaders().get(TRACE_ENABLED)),
             Pair.of(SPAN_ID + "-Req", request.getHeaders().get(SPAN_ID)),
-            Pair.of(SPAN_NAME + "-Req", request.getHeaders().get(SPAN_NAME)),
             Pair.of(TRACE_ID + "-Req", request.getHeaders().get(TRACE_ID)),
             Pair.of(TRACE_ID + "-Res", responseTraceId),
             Pair.of("raw_content_length-Req", String.valueOf(request.getRawContentLengthInBytes())),

--- a/riposte-spi/src/test/groovy/com/nike/riposte/server/logging/AccessLoggerSpec.groovy
+++ b/riposte-spi/src/test/groovy/com/nike/riposte/server/logging/AccessLoggerSpec.groovy
@@ -43,7 +43,7 @@ class AccessLoggerSpec extends Specification {
     then:
       logger.getAllLoggingEvents().size() == 1
       logger.getAllLoggingEvents().get(0).level == Level.INFO
-      logger.getAllLoggingEvents().get(0).message.contains("\"GET /test HTTP/1.1\" 210 20 \"myReferer\" \"myUserAgent\" accept-Req=- content-type-Req=- content-length-Res=- transfer_encoding-Res=- http_status_code-Res=210 error_uid-Res=- X-B3-Sampled-Req=- X-B3-SpanId-Req=- X-B3-SpanName-Req=- X-B3-TraceId-Req=- X-B3-TraceId-Res=- raw_content_length-Req=19 raw_content_length-Res=21 final_content_length-Res=20 elapsed_time_millis=20")
+      logger.getAllLoggingEvents().get(0).message.contains("\"GET /test HTTP/1.1\" 210 20 \"myReferer\" \"myUserAgent\" accept-Req=- content-type-Req=- content-length-Res=- transfer_encoding-Res=- http_status_code-Res=210 error_uid-Res=- X-B3-Sampled-Req=- X-B3-SpanId-Req=- X-B3-TraceId-Req=- X-B3-TraceId-Res=- raw_content_length-Req=19 raw_content_length-Res=21 final_content_length-Res=20 elapsed_time_millis=20")
   }
 
     def "log(): throws IllegalArgumentException if passed null request"() {
@@ -91,7 +91,7 @@ class AccessLoggerSpec extends Specification {
     when: "we call logMessageAdditions()"
       List<Pair<String, String>> result = accessLogger.logMessageAdditions(requestMock, null, responseMock, 20L)
     then:
-      result.size() == 17
+      result.size() == 16
       result.get(0) == Pair.of("accept-Req", "application/json")
       result.get(1) == Pair.of("content-type-Req", "application/json;charset=utf-8")
       result.get(2) == Pair.of("content-length-Res", "Content-LengthMock")
@@ -100,15 +100,14 @@ class AccessLoggerSpec extends Specification {
       result.get(5) == Pair.of("error_uid-Res", "error_uidMock")
       result.get(6) == Pair.of("X-B3-Sampled-Req", "X-B3-SampledMock")
       result.get(7) == Pair.of("X-B3-SpanId-Req", "X-B3-SpanIdMock")
-      result.get(8) == Pair.of("X-B3-SpanName-Req", "X-B3-SpanNameMock")
-      result.get(9) == Pair.of("X-B3-TraceId-Req", "X-B3-TraceId-ReqMock")
-      result.get(10) == Pair.of("X-B3-TraceId-Res", "X-B3-TraceId-ResMock")
-      result.get(11) == Pair.of("raw_content_length-Req", "19")
-      result.get(12) == Pair.of("raw_content_length-Res", "21")
-      result.get(13) == Pair.of("final_content_length-Res", "20")
-      result.get(14) == Pair.of("elapsed_time_millis", "20")
-      result.get(15) == Pair.of("foo", "bar")
-      result.get(16) == Pair.of("whee", "yay")
+      result.get(8) == Pair.of("X-B3-TraceId-Req", "X-B3-TraceId-ReqMock")
+      result.get(9) == Pair.of("X-B3-TraceId-Res", "X-B3-TraceId-ResMock")
+      result.get(10) == Pair.of("raw_content_length-Req", "19")
+      result.get(11) == Pair.of("raw_content_length-Res", "21")
+      result.get(12) == Pair.of("final_content_length-Res", "20")
+      result.get(13) == Pair.of("elapsed_time_millis", "20")
+      result.get(14) == Pair.of("foo", "bar")
+      result.get(15) == Pair.of("whee", "yay")
   }
     
   def "logMessageAdditions(): includes missing headers but gives them null values"() {


### PR DESCRIPTION
Mirror of Nike-Inc riposte#93
* Firms up tracking when requests start and end, and at a higher granularity (nanoseconds).
* Also tracks when the last payload chunk arrives (allows you to diagnose when slow response times are due to callers slowly trickling in their payloads).
* Removes span name from access logger output defaults - callers shouldn't be sending this and it's a waste of characters in the log message.
* Handles corner cases so that access logging is always performed, e.g. when the caller drops connection before the response has been sent.
