### PR TITLE
Mirror of Nike-Inc riposte#82

### DIFF
--- a/riposte-core/src/main/java/com/nike/riposte/server/http/ResponseSender.java
+++ b/riposte-core/src/main/java/com/nike/riposte/server/http/ResponseSender.java
@@ -1,5 +1,7 @@
 package com.nike.riposte.server.http;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nike.riposte.server.channelpipeline.ChannelAttributes;
 import com.nike.riposte.server.channelpipeline.message.ChunkedOutboundMessage;
 import com.nike.riposte.server.channelpipeline.message.OutboundMessageSendContentChunk;
@@ -12,17 +14,6 @@ import com.nike.wingtips.Span;
 import com.nike.wingtips.TraceAndSpanIdGenerator;
 import com.nike.wingtips.TraceHeaders;
 import com.nike.wingtips.Tracer;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.nio.charset.Charset;
-import java.util.UUID;
-import java.util.function.Consumer;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -39,6 +30,13 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
 
 import static com.nike.riposte.util.AsyncNettyHelper.consumerWithTracingAndMdc;
 import static com.nike.riposte.util.AsyncNettyHelper.runnableWithTracingAndMdc;
@@ -388,12 +386,11 @@ public class ResponseSender {
         actualResponseObject.headers().add(responseInfo.getHeaders());
 
         // Add cookies (if any)
-        if (responseInfo.getCookies() != null) {
-            for (Cookie cookie : responseInfo.getCookies()) {
-                actualResponseObject.headers().add(
-                    HttpHeaders.Names.SET_COOKIE, ServerCookieEncoder.LAX.encode(cookie.name(), cookie.value())
-                );
-            }
+        Set<Cookie> cookies = responseInfo.getCookies();
+        if (cookies != null && !cookies.isEmpty()) {
+            actualResponseObject.headers().add(
+                    HttpHeaders.Names.SET_COOKIE, ServerCookieEncoder.LAX.encode(cookies)
+            );
         }
     }
 

--- a/riposte-core/src/test/java/com/nike/riposte/server/http/ResponseSenderTest.java
+++ b/riposte-core/src/test/java/com/nike/riposte/server/http/ResponseSenderTest.java
@@ -1,0 +1,114 @@
+package com.nike.riposte.server.http;
+
+import com.nike.riposte.server.http.impl.FullResponseInfo;
+import com.nike.riposte.server.testutils.TestUtil;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(DataProviderRunner.class)
+public class ResponseSenderTest {
+
+    ResponseSender responseSender;
+    ChannelHandlerContext ctx;
+    ResponseInfo<?> responseInfo;
+    HttpResponse actualResponseObject;
+    RequestInfo requestInfo;
+    HttpHeaders httpHeaders;
+
+    @Before
+    public void setup() {
+        ctx = TestUtil.mockChannelHandlerContext().mockContext;
+        responseSender = new ResponseSender(null, null);
+
+        requestInfo = mock(RequestInfo.class);
+        httpHeaders = new DefaultHttpHeaders();
+
+        responseInfo = new FullResponseInfo();
+        responseInfo.setDesiredContentWriterEncoding(Charset.forName("UTF-8"));
+        responseInfo.setDesiredContentWriterMimeType("application/json");
+
+        when(requestInfo.getHeaders()).thenReturn(httpHeaders);
+    }
+
+    @DataProvider(value = {
+            "-1",
+            "0",
+            "1",
+            "2",
+            "4"
+    }, splitBy = "\\|")
+    @Test
+    public void synchronizeAndSetupResponseInfoAndFirstChunk_shouldSetCookieHeadersWhenCookiesPresent(int numberOfCookies) {
+        // given
+        actualResponseObject = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        when(requestInfo.isKeepAliveRequested()).thenReturn(false);
+
+        Set<Cookie> cookies = createCookies(numberOfCookies);
+        responseInfo.setCookies(cookies);
+
+        // when
+        responseSender.synchronizeAndSetupResponseInfoAndFirstChunk(responseInfo, actualResponseObject, requestInfo, ctx);
+
+        // then
+        List<String> setCookieHeaderValues = actualResponseObject.headers().getAll(HttpHeaders.Names.SET_COOKIE);
+
+        if (numberOfCookies > 0) {
+            assertThat(setCookieHeaderValues).isNotEmpty();
+            assertThat(setCookieHeaderValues.size()).isEqualTo(numberOfCookies);
+        } else {
+            assertThat(setCookieHeaderValues).isEmpty();
+        }
+
+        if (!setCookieHeaderValues.isEmpty()) {
+            DefaultCookie[] originalCookies = cookies.toArray(new DefaultCookie[cookies.size()]);
+            for (int x = 0; x < numberOfCookies; x++) {
+                assertThat(setCookieHeaderValues.get(x)).startsWith(originalCookies[x].name() + "=" + originalCookies[x].value());
+                assertThat(setCookieHeaderValues.get(x)).contains("Max-Age=" + originalCookies[x].maxAge());
+                if (originalCookies[x].isHttpOnly()) {
+                    assertThat(setCookieHeaderValues.get(x)).contains("HTTPOnly");
+                }
+            }
+        }
+    }
+
+    private Set<Cookie> createCookies(int numberOfCookies) {
+        if (numberOfCookies < 0) {
+            return null;
+        }
+
+        Set<Cookie> cookies = new HashSet<>();
+
+        for (int x = 0; x < numberOfCookies; x++) {
+            Cookie cookie = new DefaultCookie(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+            cookie.setHttpOnly(new Random().ints(0, 1000).findAny().getAsInt() % 2 == 0);
+            cookie.setMaxAge(new Random().longs(0, 1000).findAny().getAsLong());
+            cookies.add(cookie);
+        }
+
+        return cookies;
+    }
+
+}


### PR DESCRIPTION
Mirror of Nike-Inc riposte#82
Pass cookie from responseInfo to actual responseObject instead of creating a new cookie with just name/value from the responseInfo cookies.

the existing flow would drop any additional properties of the cookie that was set by the endpoints. Example HttpOnly flag or max age
